### PR TITLE
Feat/worker service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,9 @@ services:
     depends_on:
       rabbitmq:
         condition: service_healthy
+
+  worker:
+    build: ./worker
+    depends_on:
+      rabbitmq:
+        condition: service_healthy

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+
+WORKDIR /worker
+
+RUN pip install aio-pika===9.4.3
+
+COPY . .
+
+CMD ["python3", "main.py"]

--- a/worker/main.py
+++ b/worker/main.py
@@ -1,0 +1,21 @@
+import logging
+import signal
+import asyncio
+from src.worker import Worker
+
+logging.basicConfig(
+    format="%(asctime)s [%(levelname)s]: %(message)s",
+    level='INFO'
+)
+
+
+async def main():
+    input_queue = "jobs_queue"
+    output_queue = "results_queue"
+    worker = Worker(input_queue, output_queue)
+    signal.signal(signal.SIGTERM, lambda signum, frame: asyncio.create_task(worker.stop()))
+    await worker.start()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/worker/src/worker.py
+++ b/worker/src/worker.py
@@ -1,0 +1,49 @@
+
+import logging
+import aio_pika
+
+RABBITMQ_HOST = "rabbitmq"
+RABBITMQ_PORT = "5672"
+
+
+class Worker:
+    def __init__(self, input_queue_name, output_queue_name):
+        self.input_queue_name = input_queue_name
+        self.output_queue_name = output_queue_name
+        self.connection = None
+        self.channel = None
+        self.input_queue = None
+        self.output_queue = None
+
+    async def start(self):
+        self.connection = await aio_pika.connect_robust(
+            host=RABBITMQ_HOST,
+            port=int(RABBITMQ_PORT)
+        )
+        self.channel = await self.connection.channel()
+        await self.channel.set_qos(prefetch_count=1)
+
+        self.input_queue = await self.channel.declare_queue(self.input_queue_name, durable=True)
+        self.output_queue = await self.channel.declare_queue(self.output_queue_name, durable=True)
+
+        logging.info(f"Worker started. Consuming results from queue: {self.input_queue.name}")
+        async with self.input_queue.iterator() as queue_iter:
+            async for message in queue_iter:
+                async with message.process():
+                    await self.process_message(message)
+
+    async def stop(self):
+        await self.channel.close()
+        await self.connection.close()
+        logging.info("Worker stopped")
+
+    async def process_message(self, message):
+        # TODO: Implement processing of jobs
+        logging.info(message.body)
+
+        result = message.body
+        # Publish the result to the output queue
+        await self.channel.default_exchange.publish(
+            aio_pika.Message(body=result),
+            routing_key=self.output_queue.name,
+        )


### PR DESCRIPTION
Added worker service to consume jobs from the jobs queue and publish results in the results_queue.
Actual processing of the jobs is not done yet: it temporarily publishes the message received to the results queue.