### PR TITLE
Fix docker volumes locations to prevent creation of folders inside /api local folder

### DIFF
--- a/api/.env.EXAMPLE
+++ b/api/.env.EXAMPLE
@@ -9,8 +9,8 @@ SENDER_PASSWORD=sender_password
 SMTP_SERVER=smtp.gmail.com
 SMTP_PORT=465
 
-DATABASE_URL="sqlite:///./db/sql_app.db"
+DATABASE_URL="sqlite:///../db/sql_app.db"
 RABBITMQ_HOST=rabbitmq
 RABBITMQ_PORT=5672
 
-STORAGE_PATH=./static
+STORAGE_PATH=../static

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-WORKDIR /app
+WORKDIR /app/api
 
 COPY requirements.txt .
 

--- a/api/main.py
+++ b/api/main.py
@@ -7,6 +7,9 @@ from src.modules.wells.well_routes import wells
 from src.common.services.jobs.jobs_results_consumer import jobs_results_consumer
 from src.common.services.jobs.jobs_queue_service import jobs_queue_service
 from src.common.config.logging_config import setup_logging
+from fastapi.staticfiles import StaticFiles
+import os
+import settings
 
 
 @asynccontextmanager
@@ -35,3 +38,5 @@ app.add_middleware(
 
 app.include_router(auth)
 app.include_router(wells)
+
+app.mount("/static", StaticFiles(directory=os.path.dirname(__file__)+'/'+settings.STORAGE_PATH), name="static")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - 8080:8080
     volumes:
-      - ./api:/app
+      - ./api:/app/api
       - ./db:/app/db
       - ./static:/app/static
     depends_on:


### PR DESCRIPTION
Previously, folders such as `/db` and `/static` were wrongly created inside `/api` on startup